### PR TITLE
Fix header visibility and minor improvements

### DIFF
--- a/NiceMPNotifs.user.js
+++ b/NiceMPNotifs.user.js
@@ -84,6 +84,24 @@ function unique() {
 
 
 
+        // On bloque le header en position sticky pour conserver les notifications.
+        var $stickHeader = $(".header-sticky");
+        $stickHeader.css("position", "fixed")
+            .css("width", "100%")
+            .css("top", "0");
+
+        function forceStickyHeader() {
+            if ($stickHeader.is(".header-affix")) {
+                $stickHeader.removeClass("header-affix");
+            }
+        }
+
+        forceStickyHeader();
+
+        $(window).scroll(forceStickyHeader);
+
+
+
         var $nbNewMPArea = $(".account-number-mp");
         if ($nbNewMPArea.length !== 0) {
             setInterval(updateNbOfNewMP, 3000);

--- a/NiceMPNotifs.user.js
+++ b/NiceMPNotifs.user.js
@@ -84,35 +84,6 @@ function unique() {
 
 
 
-        /*
-        function check() {
-            //console.log("check...");
-            if ($sticky.is(".header-affix")) {
-                //console.log("is affix");
-                $sticky.removeClass("header-affix");
-            }
-        }
-
-
-
-
-        var sticky = document.querySelector(".header-sticky");
-        if (sticky === null) {
-            return;
-        }
-        var $sticky = $(sticky);
-
-        $sticky.css("position", "fixed")
-            .css("width", "100%")
-            .css("top", "0");
-
-        check();
-
-        $(window).scroll(check);
-        */
-
-
-
         var $nbNewMPArea = $(".account-number-mp");
         if ($nbNewMPArea.length !== 0) {
             setInterval(updateNbOfNewMP, 3000);

--- a/NiceMPNotifs.user.js
+++ b/NiceMPNotifs.user.js
@@ -4,7 +4,7 @@
 // @author       CrazyJeux/Daring-Do
 // @match        *://www.jeuxvideo.com/*
 // @description  Les icônes des MP et des notifications sont toujours visibles, les nombres indiqués sont régulièrement mis à jour et cliquer sur l'icône des MP amène directement à ceux-ci.
-// @version      3
+// @version      4
 // @resource     jQueryJS    https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.0/jquery.min.js
 // @grant        GM_getResourceText
 // @grant        unsafeWindow

--- a/NiceMPNotifs.user.js
+++ b/NiceMPNotifs.user.js
@@ -16,7 +16,8 @@
 var style = document.createElement("style");
 style.type = "text/css";
 style.setAttribute("data-nicempnotifs-style", "true");
-style.innerHTML = ".account-number-mp:hover, .account-number-notif:hover { font-size: 110%; } ";
+style.innerHTML = ".account-number-mp:hover, .account-number-notif:hover { transform: scale(1.4); } ";
+style.innerHTML += " .account-number { overflow: visible !important; }";
 style.innerHTML += ".account-number-mp+.account-number-notif { margin-left: 0.25rem !important; } ";
 style.innerHTML += ".account-avatar-box { margin: 0px 0.375rem 0px 0px !important; } ";
 style.innerHTML += " .header-top { display: none; }";

--- a/NiceMPNotifs.user.js
+++ b/NiceMPNotifs.user.js
@@ -9,7 +9,25 @@
 // @grant        GM_getResourceText
 // @grant        unsafeWindow
 // @grant        GM_info
+// @run-at document-start
 // ==/UserScript==
+
+// On injecte le style le plus rapidement possible pour éviter le flickering.
+var style = document.createElement("style");
+style.type = "text/css";
+style.setAttribute("data-nicempnotifs-style", "true");
+style.innerHTML = ".account-number-mp:hover, .account-number-notif:hover { font-size: 110%; } ";
+style.innerHTML += ".account-number-mp+.account-number-notif { margin-left: 0.25rem !important; } ";
+style.innerHTML += ".account-avatar-box { margin: 0px 0.375rem 0px 0px !important; } ";
+style.innerHTML += " .header-top { display: none; }";
+document.head.appendChild(style);
+
+
+// L'exécution du script est inutile dans les iframes
+var inIframe = window.top !== window.self;
+if (inIframe) {
+    return;
+}
 
 function unique() {
     function toCall() {
@@ -82,7 +100,7 @@ function unique() {
             return;
         }
         var $sticky = $(sticky);
-        
+
         $sticky.css("position", "fixed")
             .css("width", "100%")
             .css("top", "0");
@@ -100,16 +118,6 @@ function unique() {
 
 
 
-
-            var style = document.createElement("style");
-            style.type = "text/css";
-            style.setAttribute("data-nicempnotifs-style", "true");
-            style.innerHTML = ".account-number-mp:hover, .account-number-notif:hover { font-size: 110%; } ";
-            style.innerHTML += ".account-pseudo, .account-number-mp, .account-number-notif { display: inline !important; } ";
-            style.innerHTML += ".account-number-mp+.account-number-notif { margin-left: 0.25rem !important; } ";
-            style.innerHTML += ".account-avatar-box { margin: 0px 0.375rem 0px 0px !important; } ";
-            //style.innerHTML += " .header-top >.header-container { display: none; }";
-            document.head.appendChild(style);
 
             $nbNewMPArea.on("click", function(e) {
                 e.stopImmediatePropagation();
@@ -138,19 +146,30 @@ function unique() {
 
 
 
+// document.ready ne fonctionne pas sur GM avec @run-at document-start.
+// Pour vérifier que le DOM est chargé, on vérifie la présence du footer.
+var checkDomReady = setInterval(function() {
 
+    if (document.querySelector(".stats") !== null) {
+        clearInterval(checkDomReady);
 
+        // On charge jQuery, si besoin.
+        if (typeof unsafeWindow.jQuery === "undefined") {
+            var jQueryEl = document.createElement("script");
+            jQueryEl.type = "text/javascript";
+            var content = GM_getResourceText("jQueryJS");
+            jQueryEl.innerHTML = content;
+            jQueryEl.setAttribute("data-info", "jQueryJS");
+            document.head.appendChild(jQueryEl);
+        }
 
-if (typeof unsafeWindow.jQuery === "undefined") {
-    var jQueryEl = document.createElement("script");
-    jQueryEl.type = "text/javascript";
-    var content = GM_getResourceText("jQueryJS");
-    jQueryEl.innerHTML = content;
-    jQueryEl.setAttribute("data-info", "jQueryJS");
-    document.head.appendChild(jQueryEl);
-}
+        // Puis on lance le script.
+        unique();
 
-unique();
+    }
+
+}, 50);
+
 
 //Respeed
 addEventListener('instantclick:newpage', unique);


### PR DESCRIPTION
Cette PR :
- Lance le script au chargement du document pour pouvoir injecter du style plus rapidement et éviter le flickering
- Masque le grand header en tout temps pour gagner de la place
- Corrige les "sauts" au survol des MP/Notifs
- Empêche le script de s'exécuter dans les iframes (temps de calcul inutile)

J'ai testé avec DarkJVC et SpawnKill pour m'assurer que tout fonctionnait bien.
Libre à toi de merger si ces changements te conviennent :+1:
